### PR TITLE
Fix header bus line with local data

### DIFF
--- a/js/application.js
+++ b/js/application.js
@@ -52,6 +52,7 @@ define([
 
     selectBus: function (bus) {
       this.dispatcher.trigger("app:isHomeState", false);
+      console.log('App.selectBus -> MapModel.set.bus = ', bus);
       mapModel.set('bus', bus);
     },
 

--- a/js/models/mapModel.js
+++ b/js/models/mapModel.js
@@ -5,8 +5,9 @@ define([
   'underscore',
   'backbone',
   'busesnyc',
-  'oba'
-], function (_, Backbone, MtaBusTime, OneBusAway) {
+  'oba',
+  'appState'
+], function (_, Backbone, MtaBusTime, OneBusAway, appState) {
 
   var MapModel = Backbone.Model.extend({
     defaults: {
@@ -31,9 +32,14 @@ define([
 
     getBuses: function () {
 
+      console.log("MapModel.getBuses -> mta.getBuses [0]");
+
       var bus = this.get('bus'),
           dir = this.get('direction'),
           self = this;
+
+      console.log("[1] Bus:", bus, "Direction:", dir);
+
 
       if (bus) {
         // why? live spinner? I think it works without it.
@@ -41,7 +47,7 @@ define([
         // Makes more sense to trigger an event to spin/unspin from this model.
         this.trigger('getBuses');
 
-        console.log("getBuses(). Bus: [", bus, '] Direction: ', dir);
+        console.log("getBuses(). Route: [", bus, '] Direction: ', dir);
 
         this.mta.getBuses(bus, dir, function (buses) {
           self.trigger('gotBuses', buses);
@@ -51,14 +57,26 @@ define([
 
     getRoute: function () {
 
+      console.log("MapModel.getRoute -> mta.getRoute [0]");
+
       var bus = this.get('bus'),
-          self = this;
+          self = this,
+          storedBus;
 
       if (bus) {
+
+        storedBus = appState.getBus(bus) || {name: bus};
+        storedBus.color = (storedBus.color ? storedBus.color.substr(1) : "006CB7");
+        storedBus.shortName = storedBus.name;
+        self.set('route', storedBus);
+
         this.mta.getRoute(bus, function (route) {
           route.directions = _.sortBy(route.directions, function (direction) {
             return direction.directionId;
           });
+
+          console.log("MapModel.getRoute -> mta.getRoute [1]. Route:", route);
+
           self.set('route', route);
           self.getStops();
         });

--- a/js/services/appState.js
+++ b/js/services/appState.js
@@ -8,6 +8,7 @@ define(['jquery', 'storage', 'underscore', 'backbone', 'config', 'busData'], fun
     console.log('Init the AppState module instance');
     this.appInfoStorage = Storage.get('appInfo');
     this.busesStorage = Storage.get('buses');
+    this.busesLookupByName = {};
   };
 
   AppState.prototype.needsUpdate = function () {
@@ -90,6 +91,17 @@ define(['jquery', 'storage', 'underscore', 'backbone', 'config', 'busData'], fun
 
   AppState.prototype.getBuses = function () {
     return this.busesStorage;
+  };
+
+  AppState.prototype.getBus = function (name) {
+    var self = this;
+    if (_.isEmpty(this.busesLookupByName)) {
+      //cache buses by names
+      _.each(this.getBuses().data, function(i) {
+        self.busesLookupByName[i.name] = i;
+      });
+    }
+    return this.busesLookupByName[name];
   };
 
   AppState.prototype.reload = function () {


### PR DESCRIPTION
Description:

"Change the bus line header to be populated using local data in list"

"When switching buses the header area goes blank until our http request gets a response. 
We can at least populate the header with the bus line while we're waiting."
- added busesLookup object and getBus function to appStorage for fast lookup of buses by name.
- added getBus function call to MapModel to set route from local Storage before doing the ajax call
