### PR TITLE
Makes improvements to route switching when triggered from a stop bubble

### DIFF
--- a/assets/templates/busStopBubble.html
+++ b/assets/templates/busStopBubble.html
@@ -1,8 +1,10 @@
-<h2>Bus Stop</h2>
-<p>{{name}}</p>
+<h2>{{routeName}} Bus Stop</h2>
+<p>{{stop.name}}</p>
 
 <ul>
-  {{#each routes}}
-    <li><strong><a href="#buses/{{this.shortName}}">{{this.shortName}}</a></strong> to {{this.longName}}</li>
+  {{#each stop.routes}}
+    <li>
+      <a href="#" class='stop-bubble-link' data-shortname='{{this.shortName}}'>{{this.shortName}}</a> to {{this.longName}}
+    </li>
   {{/each}}
 </ul>

--- a/js/application.js
+++ b/js/application.js
@@ -24,7 +24,8 @@ define([
   AppView = Backbone.View.extend({
 
     initialize: function (options) {
-      this.dispatcher = options;
+      this.dispatcher = options.dispatcher;
+      this.router = options.router;
 
       // Let all views have a common dispatcher they can subscribe to.
       mapModel = new MapModel({apiKey: apiKey});
@@ -33,7 +34,7 @@ define([
       geoView = new GeoView({model: geoModel, dispatcher: this.dispatcher});
       liveModel = new LiveModel();
       liveView = new LiveView({model: liveModel, dispatcher: this.dispatcher});
-      mapView = new MapView({model: mapModel, liveView: liveView, dispatcher: this.dispatcher});
+      mapView = new MapView({model: mapModel, liveView: liveView, dispatcher: this.dispatcher, router: this.router});
 
       geoModel.on('change:active', this.geoLocate);
       liveModel.on('change:time', this.liveClicked);

--- a/js/models/mapModel.js
+++ b/js/models/mapModel.js
@@ -24,7 +24,11 @@ define([
       this.routeChangedCbs = [];
       this.on('change:bus', this.getBuses, this);
       this.on('change:bus', this.getRoute, this);
-      // this.on('change:bus', this.getStops, this);
+      this.on('change:currentStop', this.currentStopChanged, this);
+    },
+
+    currentStopChanged: function () {
+      console.log('Current stop changed' );
     },
 
     resetBus: function () {
@@ -68,7 +72,7 @@ define([
 
         storedBus = appState.getBus(bus) || {name: bus};
         storedBus.shortName = storedBus.name;
-        self.set('route', storedBus);
+        // self.set('route', storedBus);
 
         this.mta.getRoute(bus, function (route) {
           route.directions = _.sortBy(route.directions, function (direction) {

--- a/js/models/mapModel.js
+++ b/js/models/mapModel.js
@@ -24,11 +24,6 @@ define([
       this.routeChangedCbs = [];
       this.on('change:bus', this.getBuses, this);
       this.on('change:bus', this.getRoute, this);
-      this.on('change:currentStop', this.currentStopChanged, this);
-    },
-
-    currentStopChanged: function () {
-      console.log('Current stop changed' );
     },
 
     resetBus: function () {

--- a/js/router.js
+++ b/js/router.js
@@ -46,6 +46,7 @@ define(['jquery', 'backbone', 'domReady', 'appState'], function ($, Backbone, do
           menuBtn.style.backgroundPosition = "0 0px";
         }
       });
+
       $(document).on("click", "#map, #header-wrapper", function(){
         if($(".liveBubble").hasClass("shown")){
           $(".liveBubble").removeClass("shown");
@@ -57,7 +58,7 @@ define(['jquery', 'backbone', 'domReady', 'appState'], function ($, Backbone, do
         console.log('App required');
 
         var dispatcher = _.clone(Backbone.Events);
-        var app = new App(dispatcher);
+        var app = new App({dispatcher: dispatcher, router: router});
 
         router.on('route:homeState', function () {
 

--- a/js/views/mapView.js
+++ b/js/views/mapView.js
@@ -8,11 +8,10 @@ define([
   'leaflet',
   'shortpoll',
   'appState',
-  'markerCluster',
   'handlebars',
   'eventStack',
   'text!../../assets/templates/busStopBubble.html'
-], function ($, _, Backbone, L, ShortPoll, appState, markerCluster, H, EventStack, busStopTpl) {
+], function ($, _, Backbone, L, ShortPoll, appState, H, EventStack, busStopTpl) {
   "use strict";
 
   var RouteLayers = {
@@ -21,8 +20,8 @@ define([
   };
 
   var StopsLayers = {
-    dir0: new L.MarkerClusterGroup(),
-    dir1: new L.MarkerClusterGroup()
+    dir0: new L.LayerGroup(),
+    dir1: new L.LayerGroup()
   };
 
   var CurrentBusLayer   = new L.LayerGroup();

--- a/js/views/mapView.js
+++ b/js/views/mapView.js
@@ -163,6 +163,7 @@ define([
         e.preventDefault();
         var shortName = $(this).data('shortname');
         if (shortName.toUpperCase() !== self.model.get('bus').toUpperCase()) {
+          self.router.navigate('/buses/' + shortName);
           self.selectBus(shortName, {silent: true});
         }
       });


### PR DESCRIPTION
Switches routes from a stop bubble without the need for an event stack and a deliberate delay.
Pans the map to center when clicking on a bus stop.
Reopens the bus stop bubble for the focused stop after switching routes.
Injects route info into the bubble template.

Issues found:
The displayed routes mismatch the stops. This is because the data is inconsistent. As a result, there was a need for a try..catch clause when attempting to open a stop bubble after a route switch.
